### PR TITLE
Add subset and drop_zero arguments to plotSpatialFeature

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -361,7 +361,8 @@ getDivergeRange <- function(values, diverge_center = 0) {
                                 divergent, diverge_center, annot_divergent,
                                 annot_diverge_center, scattermore, pointsize,
                                 bins, summary_fun, hex, maxcell, show_axes, dark,
-                                palette, tx_df, rowGeometryFeatures, ...) {
+                                palette, tx_df, rowGeometryFeatures,
+                                drop_zero = FALSE, ...) {
     feature_fixed <- list(
         size = size, linewidth = linewidth, shape = shape, linetype = linetype,
         alpha = alpha, color = color, fill = fill
@@ -373,6 +374,7 @@ getDivergeRange <- function(values, diverge_center = 0) {
         plots <- lapply(features, function(n) {
             feature_aes_name <- .get_feature_aes(df[[n]], type, aes_use, shape)
             feature_aes <- setNames(list(n), feature_aes_name)
+            if (drop_zero) df <- .drop_zero_inds(df, n)
             .plot_var_sf(
                 df, annot_df, img_df, channel, type, type_annot, feature_aes, feature_fixed,
                 annot_aes, annot_fixed, tx_fixed, divergent, diverge_center,
@@ -385,6 +387,7 @@ getDivergeRange <- function(values, diverge_center = 0) {
         plots <- lapply(names(values), function(n) {
             feature_aes_name <- .get_feature_aes(df[[n]], type, aes_use, shape)
             feature_aes <- setNames(list(n), feature_aes_name)
+            if (drop_zero) df <- .drop_zero_inds(df, n)
             .plot_var_sf(
                 df, annot_df, img_df, channel, type, type_annot, feature_aes, feature_fixed,
                 annot_aes, annot_fixed, tx_fixed, divergent, diverge_center,
@@ -715,6 +718,50 @@ getDivergeRange <- function(values, diverge_center = 0) {
     data.frame(sample_id = sample_id, data = I(imgs))
 }
 
+# Which cells/spots of the samples plotted are selected by argument `subset`,
+# as a logical vector aligned to the rows of the colGeometry being plotted
+.subset_inds <- function(sfe, subset, sample_id) {
+    in_sample <- colData(sfe)$sample_id %in% sample_id
+    n_plotted <- sum(in_sample)
+    if (is.logical(subset)) {
+        if (!length(subset) %in% c(ncol(sfe), n_plotted)) {
+            stop("Logical vector `subset` must have length ncol(sfe) (",
+                 ncol(sfe), ") or the number of cells or spots in the ",
+                 "sample(s) plotted (", n_plotted, ").")
+        }
+        if (length(subset) == ncol(sfe)) subset <- subset[in_sample]
+        subset[is.na(subset)] <- FALSE
+        out <- subset
+    } else if (is.character(subset)) {
+        ids <- colnames(sfe)
+        if (is.null(ids)) {
+            stop("`sfe` does not have colnames, so `subset` can't be cell IDs.")
+        }
+        out <- ids[in_sample] %in% subset
+    } else if (is.numeric(subset)) {
+        inds <- seq_len(ncol(sfe))[subset]
+        if (anyNA(inds)) {
+            stop("`subset` has indices out of range of the columns of `sfe`.")
+        }
+        out <- (seq_len(ncol(sfe)) %in% inds)[in_sample]
+    } else {
+        stop("`subset` must be a logical vector, a character vector of cell ",
+             "IDs, or a numeric vector of column indices of `sfe`.")
+    }
+    if (!any(out)) {
+        stop("`subset` does not select any cell or spot in the sample(s) plotted.")
+    }
+    out
+}
+
+# Drop the items whose value of the feature about to be plotted is 0, so the
+# geometries of sparse features don't cover up what's plotted beneath them
+.drop_zero_inds <- function(df, feature) {
+    values <- df[[feature]]
+    if (!is.numeric(values)) return(df)
+    df[is.na(values) | values != 0, , drop = FALSE]
+}
+
 #' @importFrom rlang check_installed
 .plotSpatialFeature <- function(sfe, values, colGeometryName, sample_id, ncol,
                                 ncol_sample, annotGeometryName, annot_aes,
@@ -724,12 +771,14 @@ getDivergeRange <- function(values, diverge_center = 0) {
                                 linetype, alpha, color, fill, scattermore,
                                 pointsize, bins, summary_fun, hex, maxcell,
                                 show_axes, dark, palette, normalize_channels,
-                                rowGeometryName, rowGeometryFeatures, tx_file,...) {
+                                rowGeometryName, rowGeometryFeatures, tx_file,
+                                subset = NULL, drop_zero = FALSE, ...) {
     df <- colGeometry(sfe, colGeometryName, sample_id = sample_id)
     df$sample_id <- colData(sfe)$sample_id[colData(sfe)$sample_id %in% sample_id]
     # In case of illegal names
     names_orig <- names(values)
     df <- cbind(df[,c("geometry", "sample_id")], values)
+    if (!is.null(subset)) df <- df[.subset_inds(sfe, subset, sample_id),]
     df <- .crop(df, bbox)
     names(df)[!names(df) %in% c("geometry", "sample_id")] <- names_orig
     type_df <- .get_generalized_geometry_type(df)
@@ -775,7 +824,7 @@ getDivergeRange <- function(values, diverge_center = 0) {
         color, fill, ncol, ncol_sample, divergent,
         diverge_center, annot_divergent, annot_diverge_center, scattermore,
         pointsize, bins, summary_fun, hex, maxcell, show_axes, dark, palette,
-        tx_df, rowGeometryFeatures,...
+        tx_df, rowGeometryFeatures, drop_zero = drop_zero,...
     )
 }
 
@@ -881,6 +930,21 @@ getDivergeRange <- function(values, diverge_center = 0) {
 #'   relevant defaults for this function.
 #' @param tx_fixed Similar to \code{annot_fixed}, but to specify fixed aesthetic
 #'   for transcript spots.
+#' @param subset Which cells or spots to plot, for instance to only plot the
+#'   cells of one cluster. Can be a logical vector as long as the number of
+#'   columns of \code{sfe} or the number of cells or spots in the sample(s)
+#'   plotted, a character vector of cell IDs as in \code{colnames(sfe)}, or a
+#'   numeric vector of column indices of \code{sfe}, negative to exclude. The
+#'   cells or spots left out are not drawn at all, while the extent of the plot
+#'   and the \code{annotGeometry}, image, and transcript spots plotted are
+#'   unaffected. Defaults to \code{NULL}, which means plotting all of them.
+#' @param drop_zero Logical, whether to leave out the cells or spots whose value
+#'   of the feature being plotted is 0. Useful for sparse data such as Visium HD
+#'   at 2 micron resolution, where the geometries of the many items with 0
+#'   counts cover up the image or the transcript spots beneath them. This is
+#'   applied to each feature separately, so an item left out of the panel of one
+#'   feature is still plotted in the panel of another feature where it's
+#'   non-zero. Only applies to numeric features; \code{NA}s are kept.
 #' @param ncol Number of columns if plotting multiple features. Defaults to
 #'   \code{NULL}, which means using the same logic as \code{facet_wrap}, which
 #'   is used by \code{patchwork}'s \code{\link{wrap_plots}} by default.
@@ -993,6 +1057,12 @@ getDivergeRange <- function(values, diverge_center = 0) {
 #' plotSpatialFeature(sfe, "nCounts", colGeometryName = "spotPoly",
 #'                   annotGeometry = "myofiber_simplified",
 #'                   bbox = bbox, annot_fixed = list(linewidth = 0.3))
+#' # Only plot the spots in tissue
+#' plotSpatialFeature(sfe, "nCounts", colGeometryName = "spotPoly",
+#'                   subset = sfe$in_tissue)
+#' # Leave out the spots where the gene isn't detected
+#' plotSpatialFeature(sfe, rownames(sfe)[1], colGeometryName = "spotPoly",
+#'                   exprs_values = "counts", drop_zero = TRUE)
 plotSpatialFeature <- function(sfe, features, colGeometryName = 1L,
                                sample_id = "all", ncol = NULL,
                                ncol_sample = NULL,
@@ -1017,6 +1087,7 @@ plotSpatialFeature <- function(sfe, features, colGeometryName = 1L,
                                show_axes = FALSE, dark = FALSE,
                                palette = colorRampPalette(c("black", "white"))(255),
                                normalize_channels = FALSE,
+                               subset = NULL, drop_zero = FALSE,
                                ...) {
     aes_use <- match.arg(aes_use)
     sample_id <- .check_sample_id(sfe, sample_id, one = FALSE)
@@ -1041,7 +1112,8 @@ plotSpatialFeature <- function(sfe, features, colGeometryName = 1L,
         annot_diverge_center, size, shape, linewidth, linetype,
         alpha, color, fill, scattermore, pointsize, bins, summary_fun, hex,
         maxcell, show_axes, dark, palette, normalize_channels,
-        rowGeometryName, rowGeometryFeatures, tx_file, ...
+        rowGeometryName, rowGeometryFeatures, tx_file,
+        subset = subset, drop_zero = drop_zero, ...
     )
 }
 

--- a/man/plotSpatialFeature.Rd
+++ b/man/plotSpatialFeature.Rd
@@ -45,6 +45,8 @@ plotSpatialFeature(
   dark = FALSE,
   palette = colorRampPalette(c("black", "white"))(255),
   normalize_channels = FALSE,
+  subset = NULL,
+  drop_zero = FALSE,
   ...
 )
 }
@@ -99,6 +101,23 @@ relevant defaults for this function.}
 
 \item{tx_fixed}{Similar to \code{annot_fixed}, but to specify fixed aesthetic
 for transcript spots.}
+
+\item{subset}{Which cells or spots to plot, for instance to only plot the
+cells of one cluster. Can be a logical vector as long as the number of
+columns of \code{sfe} or the number of cells or spots in the sample(s)
+plotted, a character vector of cell IDs as in \code{colnames(sfe)}, or a
+numeric vector of column indices of \code{sfe}, negative to exclude. The
+cells or spots left out are not drawn at all, while the extent of the plot
+and the \code{annotGeometry}, image, and transcript spots plotted are
+unaffected. Defaults to \code{NULL}, which means plotting all of them.}
+
+\item{drop_zero}{Logical, whether to leave out the cells or spots whose value
+of the feature being plotted is 0. Useful for sparse data such as Visium HD
+at 2 micron resolution, where the geometries of the many items with 0
+counts cover up the image or the transcript spots beneath them. This is
+applied to each feature separately, so an item left out of the panel of one
+feature is still plotted in the panel of another feature where it's
+non-zero. Only applies to numeric features; \code{NA}s are kept.}
 
 \item{exprs_values}{Integer scalar or string indicating which assay of x
 contains the expression values.}
@@ -297,5 +316,11 @@ bbox <- c(xmin = 5500, ymin = 13500, xmax = 6000, ymax = 14000)
 plotSpatialFeature(sfe, "nCounts", colGeometryName = "spotPoly",
                   annotGeometry = "myofiber_simplified",
                   bbox = bbox, annot_fixed = list(linewidth = 0.3))
+# Only plot the spots in tissue
+plotSpatialFeature(sfe, "nCounts", colGeometryName = "spotPoly",
+                  subset = sfe$in_tissue)
+# Leave out the spots where the gene isn't detected
+plotSpatialFeature(sfe, rownames(sfe)[1], colGeometryName = "spotPoly",
+                  exprs_values = "counts", drop_zero = TRUE)
 }
 \concept{Spatial plotting}

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -143,6 +143,163 @@ test_that("Everything plotSpatialFeature", {
     })
 })
 
+# Selectively plotting cells or spots
+n_drawn <- function(g) nrow(ggplot_build(g)$data[[1]])
+in_sample01 <- colData(sfe)$sample_id == "sample01"
+counts_h <- assay(sfe, "counts")["H", in_sample01]
+counts_b <- assay(sfe, "counts")["B", in_sample01]
+
+test_that("subset says which cells or spots to plot", {
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts")),
+                 sum(in_sample01))
+    # Logical vector as long as the sample plotted
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts",
+                                            subset = counts_h > 0)),
+                 sum(counts_h > 0))
+    # Logical vector as long as the whole object
+    l <- rep(FALSE, ncol(sfe))
+    l[in_sample01] <- counts_h > 0
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts",
+                                            subset = l)),
+                 sum(counts_h > 0))
+    # NAs don't select
+    l2 <- counts_h > 0
+    l2[1] <- NA
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts",
+                                            subset = l2)),
+                 sum(l2, na.rm = TRUE))
+    # Cell IDs
+    ids <- colnames(sfe)[in_sample01][1:4]
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts",
+                                            subset = ids)),
+                 4L)
+    # Column indices, and negative indices to leave cells out
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts",
+                                            subset = which(in_sample01)[1:3])),
+                 3L)
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts",
+                                            subset = -which(in_sample01)[1])),
+                 sum(in_sample01) - 1L)
+})
+
+test_that("subset doesn't affect the annotGeometry plotted", {
+    args <- list(sfe, "H", "spotPoly", "sample01", exprs_values = "counts",
+                 annotGeometryName = "annot", annot_aes = list(fill = "bar"))
+    n_all <- vapply(ggplot_build(do.call(plotSpatialFeature, args))$data,
+                    nrow, FUN.VALUE = integer(1))
+    n_sub <- vapply(ggplot_build(do.call(plotSpatialFeature,
+                                         c(args, list(subset = counts_h > 0))))$data,
+                    nrow, FUN.VALUE = integer(1))
+    # Only the layer of the colGeometry has fewer geometries
+    expect_equal(sum(n_all != n_sub), 1L)
+    expect_equal(unname(n_sub[n_all != n_sub]), sum(counts_h > 0))
+})
+
+test_that("subset must make sense", {
+    expect_error(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                    exprs_values = "counts",
+                                    subset = c(TRUE, FALSE)),
+                 "must have length")
+    expect_error(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                    exprs_values = "counts",
+                                    subset = rep(FALSE, sum(in_sample01))),
+                 "does not select any cell or spot")
+    expect_error(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                    exprs_values = "counts",
+                                    subset = "not a cell"),
+                 "does not select any cell or spot")
+    expect_error(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                    exprs_values = "counts",
+                                    subset = ncol(sfe) + 1L),
+                 "out of range")
+    expect_error(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                    exprs_values = "counts",
+                                    subset = list(TRUE)),
+                 "must be a logical vector")
+})
+
+test_that("drop_zero leaves out the items whose value is 0", {
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts",
+                                            drop_zero = TRUE)),
+                 sum(counts_h > 0))
+    # Applied to each feature separately, so a spot left out of one panel is
+    # still plotted in the panel of another feature where it's non-zero
+    p <- plotSpatialFeature(sfe, c("H", "B"), "spotPoly", "sample01",
+                            exprs_values = "counts", drop_zero = TRUE)
+    expect_equal(n_drawn(p[[1]]), sum(counts_h > 0))
+    expect_equal(n_drawn(p[[2]]), sum(counts_b > 0))
+    expect_false(sum(counts_h > 0) == sum(counts_b > 0))
+    # NAs are kept
+    sfe2 <- sfe
+    v <- assay(sfe2, "counts")["H",]
+    v[which(v == 0)[1]] <- NA
+    assay(sfe2, "counts")["H",] <- v
+    expect_equal(n_drawn(plotSpatialFeature(sfe2, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts",
+                                            drop_zero = TRUE)),
+                 sum(counts_h > 0) + 1L)
+})
+
+test_that("drop_zero only applies to numeric features", {
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "category", "centroids",
+                                            "sample01", size = 2,
+                                            drop_zero = TRUE)),
+                 sum(in_sample01))
+})
+
+test_that("subset and drop_zero can be used together", {
+    keep <- rep(TRUE, sum(in_sample01))
+    keep[which(counts_h > 0)[1]] <- FALSE
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "sample01",
+                                            exprs_values = "counts",
+                                            subset = keep, drop_zero = TRUE)),
+                 sum(counts_h > 0) - 1L)
+})
+
+test_that("subset and drop_zero apply when plotting multiple samples", {
+    counts_all <- assay(sfe, "counts")["H",]
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "all",
+                                            exprs_values = "counts",
+                                            subset = counts_all > 0)),
+                 sum(counts_all > 0))
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "spotPoly", "all",
+                                            exprs_values = "counts",
+                                            drop_zero = TRUE)),
+                 sum(counts_all > 0))
+})
+
+test_that("subset and drop_zero apply when points are rasterized", {
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "centroids", "sample01",
+                                            exprs_values = "counts",
+                                            scattermore = TRUE,
+                                            drop_zero = TRUE)),
+                 sum(counts_h > 0))
+    expect_equal(n_drawn(plotSpatialFeature(sfe, "H", "centroids", "sample01",
+                                            exprs_values = "counts",
+                                            scattermore = TRUE,
+                                            subset = counts_h > 0)),
+                 sum(counts_h > 0))
+})
+
+test_that("drop_zero on a feature that is 0 everywhere plots nothing", {
+    sfe2 <- sfe
+    colData(sfe2)$all_zero <- 0
+    expect_ggplot("Nothing left to plot",
+                  plotSpatialFeature(sfe2, "all_zero", "spotPoly", "sample01",
+                                     drop_zero = TRUE))
+    expect_equal(n_drawn(plotSpatialFeature(sfe2, "all_zero", "spotPoly",
+                                            "sample01", drop_zero = TRUE)),
+                 0L)
+})
+
 # Real dataset
 library(SFEData)
 sfe_muscle <- McKellarMuscleData("small")


### PR DESCRIPTION
This PR proposes adding `subset` and `drop_zero` arguments to `plotSpatialFeature`, so only the cells or spots you want are drawn (Fixes #39). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/236. You can sign in with your GitHub ID to claim ownership of the project.

## What this adds

#39 asks for "new argument(s) in plotSpatialFeature to selectively plot cells or spots ... such as not plotting items with 0 value, only plotting cells from a given cluster", and notes that the 0-value case matters for Visium HD at 2 micron resolution, where the geometries of the many empty items cover up whatever is plotted beneath them. This adds both, as two arguments of `plotSpatialFeature`:

- `subset` — which cells or spots to draw. Takes a logical vector as long as `ncol(sfe)` or as the number of items in the sample(s) plotted, a character vector of cell IDs from `colnames(sfe)`, or column indices, negative to leave items out. The items not selected are not drawn at all, while the extent of the plot, the `annotGeometry`, the image, and the transcript spots are unaffected.
- `drop_zero` — leave out the items whose value of the feature being plotted is 0. It is applied to each feature separately, so a spot left out of the panel of one gene is still drawn in the panel of another gene where it is non-zero. Numeric features only, and `NA`s are kept.

Both default to today's behaviour (`NULL` and `FALSE`) and both were appended after `normalize_channels`, just before `...`, so no existing call changes meaning, positional or named.

## The state on devel today

Neither behaviour is reachable, and because `plotSpatialFeature` forwards `...` to `wrap_plots`, asking for it is swallowed silently instead of erroring, so the plot simply comes back unfiltered. Reproduced on `devel` at 25d880e using the toy object your tests already ship, so there is nothing to download:

```r
sfe <- readRDS(system.file("extdata/sfe.rds", package = "Voyager"))
v <- SummarizedExperiment::assay(sfe, "counts")["H", colData(sfe)$sample_id == "sample01"]
sum(v == 0)                                        # 10 of the 13 spots are 0
n <- function(p) nrow(ggplot_build(p)$data[[1]])   # spots actually drawn
n(plotSpatialFeature(sfe, "H", "spotPoly", "sample01", exprs_values = "counts"))
n(plotSpatialFeature(sfe, "H", "spotPoly", "sample01", exprs_values = "counts", subset = v > 0))
n(plotSpatialFeature(sfe, "H", "spotPoly", "sample01", exprs_values = "counts", drop_zero = TRUE))
```

```
[1] 10
[1] 13
[1] 13      # subset = v > 0 ignored
[1] 13      # drop_zero = TRUE ignored
```

With this branch installed, the same three lines give `13`, `3` and `3`.

## How this was verified

- Nine test blocks with 28 assertions were added to `tests/testthat/test-plot.R`, beside the existing toy-object tests so they need no download: all three input types for `subset` plus negative indices and `NA`s, its four validation errors, `drop_zero` per feature across a two-feature `patchwork`, `NA`s kept, a feature that is 0 everywhere, a discrete feature where `drop_zero` is a no-op, both arguments together, both across two samples at once, both on the rasterised `scattermore` path, and a check that the `annotGeometry` layer keeps every geometry when the `colGeometry` layer loses some.
- Those tests are red on `devel` at 25d880e: 8 of the 9 blocks fail there, 23 failed assertions. The ninth is the discrete-feature no-op, which is green either way by design.
- Full `testthat` suite run on the clean tree and again on this branch, in the same container: 127 tests before, 136 after, no new failures. The five errors are identical on both sides and none are from this change — three variogram tests in `test-gstat.R`, and `test-plot.R` and `test-plot-transcripts.R` both stopping at `getPixelSize()` because I have no `RBioFormats` installed.
- `tools::codoc()` and `tools::undoc()` report nothing for the new arguments. `man/plotSpatialFeature.Rd` was edited by hand to match the roxygen block, so the diff carries no unrelated documentation churn.

One judgement call worth your review: the two arguments are exposed on `plotSpatialFeature` only, matching the wording of #39, but they are implemented on the shared internals `.plotSpatialFeature` and `.wrap_spatial_plots`, so exposing them on `plotLocalResult` and `spatialReducedDim` too is a one-line change each if you want them there. I left that to you rather than widening the surface uninvited. Naming is likewise yours to call.

## How this was managed

We ran this work on a live agile board imported from this repository's own issues and pull requests — 58 stories and 11 labels — where it is the story [New argument(s) in plotSpatialFeature to selectively plot cells or spots](https://eastagiletracker.com/projects/236/stories/101655) on [this board](https://eastagiletracker.com/projects/236).

![board](https://raw.githubusercontent.com/eastagiletracker/voyager/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
